### PR TITLE
Increase-size-of-Graph-plot-window-in-Linux-wallet

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -490,7 +490,7 @@
           <property name="minimumSize">
            <size>
             <width>0</width>
-            <height>100</height>
+            <height>190</height>
            </size>
           </property>
          </widget>


### PR DESCRIPTION
Hi,
The graph plot window in the overview page in the Linux wallet is jammed and the numbers on the y axis are unreadable. Increased window size a bit!

Cheers,
Youssef